### PR TITLE
Update to upstream level 3 spells

### DIFF
--- a/PAK/Public/Arcanist/Progressions/Progressions.lsx
+++ b/PAK/Public/Arcanist/Progressions/Progressions.lsx
@@ -72,7 +72,7 @@
                     <attribute id="PassivesAdded" type="LSString" value=""/>
                     <attribute id="PassivesRemoved" type="LSString" value=""/>
                     <attribute id="ProgressionType" type="uint8" value="0"/>
-                    <attribute id="Selectors" type="LSString" value="SelectSpells(62ada699-749b-491e-bfab-47aa15340380,1,1,SorcererSpell)"/>
+                    <attribute id="Selectors" type="LSString" value="SelectSpells(22755771-ca11-49f4-b772-13d8b8fecd93,1,1,SorcererSpell)"/>
                     <attribute id="TableUUID" type="guid" value="d8787f19-5c06-4b6e-8123-f86cb82da7e9"/>
                     <attribute id="UUID" type="guid" value="ab1c9838-789a-4e98-af2e-72eddafaa40c"/>
                 </node>
@@ -84,7 +84,7 @@
                     <attribute id="PassivesAdded" type="LSString" value=""/>
                     <attribute id="PassivesRemoved" type="LSString" value=""/>
                     <attribute id="ProgressionType" type="uint8" value="0"/>
-                    <attribute id="Selectors" type="LSString" value="SelectSpells(62ada699-749b-491e-bfab-47aa15340380,1,1,SorcererSpell)"/>
+                    <attribute id="Selectors" type="LSString" value="SelectSpells(22755771-ca11-49f4-b772-13d8b8fecd93,1,1,SorcererSpell)"/>
                     <attribute id="TableUUID" type="guid" value="d8787f19-5c06-4b6e-8123-f86cb82da7e9"/>
                     <attribute id="UUID" type="guid" value="1b6368b7-6096-4371-8cce-625cc169d49b"/>
                 </node>


### PR DESCRIPTION
Character level 5 introduced 3rd spell levels. This change switches the spell list to the upstream wizard 3rd level spells.